### PR TITLE
Upgrade Cheerio

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "test"
   },
   "dependencies": {
-    "cheerio": "~0.16.0",
+    "cheerio": "~0.17.0",
     "optimist": "~0.6.1",
     "lodash": "~2.4.1",
     "xregexp": "~2.0.0"


### PR DESCRIPTION
Tests pass.

I'd like to upgrade this for a selfish reason - I'm using Unfluff in a Meteor app alongside the latest Cheerio release - 0.17. Meteor can't handle the different versions of Cheerio (0.16 vs 0.17), so including 0.17 would really help me out. Thanks!
