### PR TITLE
Replace "null" to empty string

### DIFF
--- a/src/extractor.coffee
+++ b/src/extractor.coffee
@@ -522,10 +522,10 @@ postCleanup = (doc, targetNode, lang) ->
   return node
 
 cleanNull = (text) ->
-  return text.replace(/^null$/g, "")
+  return text?.replace(/^null$/g, "")
 
 cleanText = (text) ->
-  return text.replace(/[\r\n\t]/g, " ").replace(/\s\s+/g, " ").replace(/<!--.+?-->/g, "").replace(/�/g, "").trim()
+  return text?.replace(/[\r\n\t]/g, " ").replace(/\s\s+/g, " ").replace(/<!--.+?-->/g, "").replace(/�/g, "").trim()
 
 
 cleanTitle = (title, delimiters) ->

--- a/src/extractor.coffee
+++ b/src/extractor.coffee
@@ -28,7 +28,7 @@ module.exports =
     span[class*='date'], \
     p[class*='date'], \
     div[class*='date']")
-    dateCandidates?.first()?.attr("content")?.trim() || dateCandidates?.first()?.attr("datetime")?.trim() || cleanText(dateCandidates?.first()?.text()) || null
+    cleanNull(dateCandidates?.first()?.attr("content"))?.trim() || cleanNull(dateCandidates?.first()?.attr("datetime"))?.trim() || cleanText(dateCandidates?.first()?.text()) || null
 
 
   # Grab the copyright line
@@ -55,7 +55,7 @@ module.exports =
     meta[name='creator']")
     authorList = []
     authorCandidates.each () ->
-      author = doc(this)?.attr("content")?.trim()
+      author = cleanNull(doc(this)?.attr("content"))?.trim()
       if author
         authorList.push(author)
     # fallback to a named author div
@@ -74,7 +74,7 @@ module.exports =
     meta[name='dc.publisher'], \
     meta[name='DC.publisher'], \
     meta[name='DC.Publisher']")
-    publisherCandidates?.first()?.attr("content")?.trim()
+    cleanNull(publisherCandidates?.first()?.attr("content"))?.trim()
 
 
   # Grab the title of an html doc (excluding junk)
@@ -101,8 +101,8 @@ module.exports =
   image: (doc) ->
     images = doc("meta[property='og:image'], meta[itemprop=image], meta[name='twitter:image:src'], meta[name='twitter:image'], meta[name='twitter:image0']")
 
-    if images.length > 0 && images.first().attr('content')
-      return images.first().attr('content')
+    if images.length > 0 && cleanNull(images.first().attr('content'))
+      return cleanNull(images.first().attr('content'))
 
     null
 
@@ -181,17 +181,17 @@ module.exports =
   # Get the meta description of an html doc
   description: (doc) ->
     tag = doc("meta[name=description], meta[property='og:description']")
-    tag?.first()?.attr("content")?.trim()
+    cleanNull(tag?.first()?.attr("content"))?.trim()
 
   # Get the meta keywords of an html doc
   keywords: (doc) ->
     tag = doc("meta[name=keywords]")
-    tag?.attr("content")
+    cleanNull(tag?.attr("content"))
 
   # Get the canonical link of an html doc
   canonicalLink: (doc) ->
     tag = doc("link[rel=canonical]")
-    tag?.attr("href")
+    cleanNull(tag?.attr("href"))
 
   # Get any tags or keywords from an html doc
   tags: (doc) ->
@@ -521,6 +521,8 @@ postCleanup = (doc, targetNode, lang) ->
 
   return node
 
+cleanNull = (text) ->
+  return text.replace(/^null$/g, "")
 
 cleanText = (text) ->
   return text.replace(/[\r\n\t]/g, " ").replace(/\s\s+/g, " ").replace(/<!--.+?-->/g, "").replace(/�/g, "").trim()

--- a/src/extractor.coffee
+++ b/src/extractor.coffee
@@ -74,7 +74,7 @@ module.exports =
     meta[name='dc.publisher'], \
     meta[name='DC.publisher'], \
     meta[name='DC.Publisher']")
-    cleanNull(publisherCandidates?.first()?.attr("content"))?.trim()
+    cleanNull(publisherCandidates?.first()?.attr("content"))?.trim() || null
 
 
   # Grab the title of an html doc (excluding junk)

--- a/test/extractor.coffee
+++ b/test/extractor.coffee
@@ -75,6 +75,11 @@ suite 'Extractor', ->
     date = extractor.date(doc)
     eq date, "2010-05-24T13:47:52+0000"
 
+  test 'returns nothing if date eq "null"', ->
+    doc = cheerio.load("<html><head><meta property=\"article:published_time\" content=\"null\" /></head></html>")
+    date = extractor.date(doc)
+    eq date, null
+
   test 'returns the copyright line element', ->
     doc = cheerio.load("<html><head></head><body><div>Some stuff</div><ul><li class='copyright'><!-- // some garbage -->© 2016 The World Bank Group, All Rights Reserved.</li></ul></body></html>")
     copyright = extractor.copyright(doc)
@@ -105,8 +110,22 @@ suite 'Extractor', ->
       author = extractor.author(doc)
       eq JSON.stringify(author), JSON.stringify(["Gary Trust"])
 
+  test 'returns the meta author but ignore "null" value', ->
+    doc = cheerio.load("<html><head><meta property=\"article:author\" content=\"null\" /><meta name=\"author\" content=\"Joe Bloggs\" /></head></html>")
+    author = extractor.author(doc)
+    eq JSON.stringify(author), JSON.stringify(["Joe Bloggs"])
+
   test 'returns the meta publisher', ->
     doc = cheerio.load("<html><head><meta property=\"og:site_name\" content=\"Polygon\" /><meta name=\"author\" content=\"Griffin McElroy\" /></head></html>")
     publisher = extractor.publisher(doc)
     eq publisher, "Polygon"
 
+  test 'returns nothing if publisher eq "null"', ->
+    doc = cheerio.load("<html><head><meta property=\"og:site_name\" content=\"null\" /></head></html>")
+    publisher = extractor.publisher(doc)
+    eq publisher, null
+
+  test 'returns nothing if image eq "null"', ->
+    doc = cheerio.load("<html><head><meta property=\"og:image\" content=\"null\" /></head></html>")
+    image = extractor.image(doc)
+    eq image, null


### PR DESCRIPTION
On some pages the meta attributes like og:image, author or date have "null" (string) value so this should be replaced with null or empty string.