### PR TITLE
[Emergency]Change cheerio version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "test"
   },
   "dependencies": {
-    "cheerio": "~0.17.0",
+    "cheerio": "~0.22.0",
     "optimist": "~0.6.1",
     "lodash": "~2.4.1",
     "xregexp": "~2.0.0"


### PR DESCRIPTION
This sentence generates errors. (cheerio/index.js)
'exports.version = require('./package').version;'
and This sentence should be change to 'exports.version =
require('./package,json').version;'