### PR TITLE
add itemprop=name to extractor; also fix techcrunch1 test

### DIFF
--- a/fixtures/test_techcrunch1.json
+++ b/fixtures/test_techcrunch1.json
@@ -30,7 +30,7 @@
                 "href": "http://money.cnn.com/popups/2006/biz2/peoplewhodontmatter/frameset.exclude.html"
             },
             {
-                "text": "<img src=\"http://tctechcrunch2011.files.wordpress.com/2011/08/screen-shot-2011-08-13-at-6-43-20-pm1.png?w=620&amp;h=393\" alt=\"\" title=\"Screen Shot 2011-08-13 at 6.43.20 PM\" width=\"620\" height=\"393\" class=\"alignnone size-full wp-image-406259\">",
+                "text": "<img src=\"http://tctechcrunch2011.files.wordpress.com/2011/08/screen-shot-2011-08-13-at-6-43-20-pm1.png?w=620&amp;h=393\" alt title=\"Screen Shot 2011-08-13 at 6.43.20 PM\" width=\"620\" height=\"393\" class=\"alignnone size-full wp-image-406259\">",
                 "href": "http://tctechcrunch2011.files.wordpress.com/2011/08/screen-shot-2011-08-13-at-6-43-20-pm1.png"
             }
         ]

--- a/lib/extractor.js
+++ b/lib/extractor.js
@@ -41,7 +41,7 @@ void function () {
     },
     publisher: function (doc) {
       var cache$, cache$1, publisherCandidates;
-      publisherCandidates = doc("meta[property='og:site_name'],     meta[name='dc.publisher'],     meta[name='DC.publisher'],     meta[name='DC.Publisher']");
+      publisherCandidates = doc("meta[property='og:site_name'],     meta[itemprop=name],     meta[name='dc.publisher'],     meta[name='DC.publisher'],     meta[name='DC.Publisher']");
       return (null != (cache$ = cleanNull(null != publisherCandidates && null != (cache$1 = publisherCandidates.first()) ? cache$1.attr('content') : void 0)) ? cache$.trim() : void 0) || null;
     },
     title: function (doc) {

--- a/src/extractor.coffee
+++ b/src/extractor.coffee
@@ -71,6 +71,7 @@ module.exports =
   # Grab the publisher of the page/site
   publisher: (doc) ->
     publisherCandidates = doc("meta[property='og:site_name'], \
+    meta[itemprop=name], \
     meta[name='dc.publisher'], \
     meta[name='DC.publisher'], \
     meta[name='DC.Publisher']")

--- a/test/extractor.coffee
+++ b/test/extractor.coffee
@@ -120,6 +120,10 @@ suite 'Extractor', ->
     publisher = extractor.publisher(doc)
     eq publisher, "Polygon"
 
+    doc2 = cheerio.load("<html><head><meta itemProp=\"name\" content=\"The New York Times\"></head></html>")
+    publisher2 = extractor.publisher(doc2)
+    eq publisher2, "The New York Times"
+
   test 'returns nothing if publisher eq "null"', ->
     doc = cheerio.load("<html><head><meta property=\"og:site_name\" content=\"null\" /></head></html>")
     publisher = extractor.publisher(doc)


### PR DESCRIPTION
The New York Times leverages the schema.org `itemprop = name` microdata to denote their publisher value.

example: view-source:https://www.nytimes.com/2019/08/12/world/asia/hong-kong-airport-protest-cancellations.html

just wanted to enhance this library to support that.

also fixed the test failure on `make test` for `techcrunch1` links

